### PR TITLE
Add rudimentary simulation endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ Interacts between [SUMO](https://www.eclipse.org/sumo/) and Urbanflo app.
 1. Clone the repository
 2. Run `./gradlew build` to build
 
-## Proof of concept/demo
+## Deploy
 
-Runs SUMO through one of the demo files. Available on the `kotlin-demo` branch.
-
-Run with `java -jar build/libs/urbanflo-sumo-server-0.0.1-SNAPSHOT.jar`
-
-**Do not merger the `kotlin-demo` branch!!!**
+```shell
+java -jar build/libs/urbanflo-sumo-server-0.0.1-SNAPSHOT.jar
+```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,14 +23,14 @@ repositories {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    implementation("org.springframework.boot:spring-boot-starter-web:3.1.0")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.14.2")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:1.8.20-RC")
+    testImplementation("org.springframework.boot:spring-boot-starter-test:3.1.0")
     implementation("io.github.oshai:kotlin-logging-jvm:4.0.0-beta-29")
-    implementation("org.slf4j:slf4j-api:2.0.7")
     implementation("org.eclipse.sumo:libsumo:1.18.0-SNAPSHOT")
     implementation("org.eclipse.sumo:libtraci:1.18.0-SNAPSHOT")
+    implementation("io.projectreactor:reactor-core:3.5.4")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationController.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationController.kt
@@ -4,17 +4,12 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 import reactor.core.publisher.Flux
-import java.time.Duration
-import java.time.LocalDateTime
 
 @Controller
 class SimulationController {
     @GetMapping("/start-simulation", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
-    fun startSimulation(): Flux<String> {
+    fun startSimulation(): Flux<SimulationStep> {
         val cfgPath = System.getenv("SUMOCFG_PATH") ?: "demo/demo.sumocfg"
-
-        return Flux.interval(Duration.ofSeconds(1)).map { seq ->
-            "Current time: ${LocalDateTime.now()}"
-        }
+        return Flux.fromIterable(SimulationInstance(cfgPath))
     }
 }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationController.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationController.kt
@@ -1,0 +1,20 @@
+package app.urbanflo.urbanflosumoserver
+
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+import reactor.core.publisher.Flux
+import java.time.Duration
+import java.time.LocalDateTime
+
+@Controller
+class SimulationController {
+    @GetMapping("/start-simulation", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    fun startSimulation(): Flux<String> {
+        val cfgPath = System.getenv("SUMOCFG_PATH") ?: "demo/demo.sumocfg"
+
+        return Flux.interval(Duration.ofSeconds(1)).map { seq ->
+            "Current time: ${LocalDateTime.now()}"
+        }
+    }
+}

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationInstance.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationInstance.kt
@@ -1,18 +1,14 @@
 package app.urbanflo.urbanflosumoserver
 
 import java.net.ServerSocket
-import java.util.UUID
+import java.util.*
 
 
 typealias SimulationStep = Map<String, VehiclePosition>
 
 class SimulationInstance(val cfgPath: String = "demo.sumocfg") : Iterable<SimulationStep> {
-    val port: Int
-    val label: String
-    init {
-        port = getNextAvailablePort()
-        label = UUID.randomUUID().toString()
-    }
+    val port: Int = getNextAvailablePort()
+    val label: String = UUID.randomUUID().toString()
 
     override fun iterator(): Iterator<SimulationStep> {
         return SimulationInstanceIterator(this)

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationInstance.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationInstance.kt
@@ -1,10 +1,30 @@
 package app.urbanflo.urbanflosumoserver
 
+import java.net.ServerSocket
+import java.util.UUID
+
 
 typealias SimulationStep = Map<String, VehiclePosition>
 
 class SimulationInstance(val cfgPath: String = "demo.sumocfg") : Iterable<SimulationStep> {
+    val port: Int
+    val label: String
+    init {
+        port = getNextAvailablePort()
+        label = UUID.randomUUID().toString()
+    }
+
     override fun iterator(): Iterator<SimulationStep> {
         return SimulationInstanceIterator(this)
+    }
+
+    companion object {
+        private fun getNextAvailablePort(): Int {
+            // https://stackoverflow.com/questions/2675362/how-to-find-an-available-port
+            val socket = ServerSocket(0)
+            val socketPort = socket.localPort
+            socket.close()
+            return socketPort
+        }
     }
 }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationInstance.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationInstance.kt
@@ -1,0 +1,10 @@
+package app.urbanflo.urbanflosumoserver
+
+
+typealias SimulationStep = Map<String, VehiclePosition>
+
+class SimulationInstance(val cfgPath: String = "demo.sumocfg") : Iterable<SimulationStep> {
+    override fun iterator(): Iterator<SimulationStep> {
+        return SimulationInstanceIterator(this)
+    }
+}

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationInstanceIterator.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationInstanceIterator.kt
@@ -1,0 +1,45 @@
+package app.urbanflo.urbanflosumoserver
+
+import org.eclipse.sumo.libtraci.Simulation
+import org.eclipse.sumo.libtraci.StringVector
+import org.eclipse.sumo.libtraci.Vehicle
+import kotlin.random.Random
+
+class SimulationInstanceIterator
+    (simulationInstance: SimulationInstance) : Iterator<SimulationStep> {
+    private val vehicleColors: MutableMap<String, String> = mutableMapOf()
+
+    init {
+        System.loadLibrary("libtracijni")
+        Simulation.start(StringVector(arrayOf("sumo", "-c", simulationInstance.cfgPath)))
+    }
+
+    override fun hasNext(): Boolean {
+        return Simulation.getMinExpectedNumber() > 0
+    }
+
+    override fun next(): SimulationStep {
+        Simulation.step()
+        val pairs = Vehicle.getIDList().map { vehicleId ->
+            val position = Vehicle.getPosition(vehicleId)
+            val color = getVehicleColor(vehicleId)
+            vehicleId to VehiclePosition(position.x, position.y, color)
+        }
+        return pairs.toMap()
+    }
+
+    private fun getVehicleColor(vehicleId: String): String {
+        // if let color = vehicleColors[vehicleId] { return color } else { assign random colour to vehicle and return }
+        val color = vehicleColors[vehicleId] ?: run {
+            val newColor = randomColor()
+            vehicleColors[vehicleId] = randomColor()
+            newColor
+        }
+        return color
+    }
+
+    private fun randomColor(): String {
+        val randBytes = Random.Default.nextBytes(3)
+        return "#${"%02X".format(randBytes[0])}${"%02X".format(randBytes[1])}${"%02X".format(randBytes[2])}"
+    }
+}

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationInstanceIterator.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/SimulationInstanceIterator.kt
@@ -18,8 +18,13 @@ class SimulationInstanceIterator
 
     init {
         System.loadLibrary("libtracijni")
-        logger.info {"Connecting to SUMO with port ${simulationInstance.port} and label ${simulationInstance.label}"}
-        Simulation.start(StringVector(arrayOf("sumo", "-c", simulationInstance.cfgPath)), simulationInstance.port, DEFAULT_NUM_RETRIES, simulationInstance.label)
+        logger.info { "Connecting to SUMO with port ${simulationInstance.port} and label ${simulationInstance.label}" }
+        Simulation.start(
+            StringVector(arrayOf("sumo", "-c", simulationInstance.cfgPath)),
+            simulationInstance.port,
+            DEFAULT_NUM_RETRIES,
+            simulationInstance.label
+        )
     }
 
     override fun hasNext(): Boolean {
@@ -27,7 +32,7 @@ class SimulationInstanceIterator
         return if (Simulation.getMinExpectedNumber() > 0) {
             true
         } else {
-            logger.info {"Closing connection with label: ${Simulation.getLabel()}"}
+            logger.info { "Closing connection with label: ${Simulation.getLabel()}" }
             Simulation.close()
             false
         }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/UrbanfloSumoServerApplication.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/UrbanfloSumoServerApplication.kt
@@ -1,15 +1,11 @@
 package app.urbanflo.urbanflosumoserver
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-
-private val logger = KotlinLogging.logger {}
 
 @SpringBootApplication
 class UrbanfloSumoServerApplication
 
 fun main(args: Array<String>) {
-    logger.info { "Starting Spring Boot" }
     runApplication<UrbanfloSumoServerApplication>(*args)
 }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/UrbanfloSumoServerApplication.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/UrbanfloSumoServerApplication.kt
@@ -10,8 +10,6 @@ private val logger = KotlinLogging.logger {}
 class UrbanfloSumoServerApplication
 
 fun main(args: Array<String>) {
-    logger.info { "Loading SUMO library" }
-    System.loadLibrary("libsumojni")
     logger.info { "Starting Spring Boot" }
     runApplication<UrbanfloSumoServerApplication>(*args)
 }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/UrbanfloSumoServerApplication.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/UrbanfloSumoServerApplication.kt
@@ -4,9 +4,14 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
+private val logger = KotlinLogging.logger {}
+
 @SpringBootApplication
 class UrbanfloSumoServerApplication
 
 fun main(args: Array<String>) {
+    logger.info { "Loading SUMO library" }
+    System.loadLibrary("libsumojni")
+    logger.info { "Starting Spring Boot" }
     runApplication<UrbanfloSumoServerApplication>(*args)
 }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/VehiclePosition.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/VehiclePosition.kt
@@ -1,0 +1,7 @@
+package app.urbanflo.urbanflosumoserver
+
+data class VehiclePosition(
+    val x: Double,
+    val y: Double,
+    val color: String
+)


### PR DESCRIPTION
This is just a straight translation from the old TS/python code. There are quite a few problems with how it is now, especially when it comes to running more than one simulation at the same time (libtraci's API is atrocious imo), but this should work as a temporary solution in line with the frontend.