### PR TITLE
Remove special treatment of demo simulation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,6 @@ RUN apt-get update && apt-get install -y libxerces-c3.2 libproj22 libfox-1.6-0 l
 WORKDIR $SUMO_HOME/bin
 COPY --from=sumo-builder /opt/sumo/bin .
 WORKDIR /opt/urbanflo-sumo-server
-# copy demo folder
-COPY demo uploads/demo
 # copy server jar
 COPY --from=gradle-builder /opt/urbanflo-sumo-server/build/libs/urbanflo-sumo-server-$VERSION.jar urbanflo-sumo-server.jar
 

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
@@ -26,7 +26,6 @@ import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.*
-import org.springframework.web.server.ResponseStatusException
 import reactor.core.Disposable
 
 private val logger = KotlinLogging.logger {}
@@ -118,21 +117,12 @@ class SimulationController(
                 responseCode = "404",
                 description = "Simulation not found",
                 content = [Content(schema = Schema(implementation = ErrorResponse::class))]
-            ),
-            ApiResponse(
-                responseCode = "403",
-                description = "Attempt to delete demo simulation",
-                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
             )
         ]
     )
     @DeleteMapping("/simulation/{id:.+}", produces = ["application/json"])
     @ResponseBody
     fun deleteSimulation(@PathVariable id: SimulationId) {
-        // prevent demo simulation from being modified or deleted
-        if (id.trim() == "demo") {
-            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Demo simulation cannot be modified or deleted via API")
-        }
         storageService.delete(id.trim())
     }
 
@@ -143,11 +133,6 @@ class SimulationController(
             ApiResponse(
                 responseCode = "404",
                 description = "Simulation not found",
-                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
-            ),
-            ApiResponse(
-                responseCode = "403",
-                description = "Attempt to modify demo simulation",
                 content = [Content(schema = Schema(implementation = ErrorResponse::class))]
             ),
             ApiResponse(
@@ -165,12 +150,7 @@ class SimulationController(
     @PutMapping("/simulation/{id:.+}", consumes = ["application/json"], produces = ["application/json"])
     @ResponseBody
     fun modifySimulation(@PathVariable id: SimulationId, @RequestBody network: SumoNetwork): SimulationInfo {
-        // prevent demo simulation from being modified or deleted
-        if (id.trim() == "demo") {
-            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Demo simulation cannot be modified or deleted via API")
-        } else {
-            return storageService.store(id, network)
-        }
+        return storageService.store(id, network)
     }
 
     @Operation(summary = "Get simulation information.")

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/storage/FilesystemStorageService.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/storage/FilesystemStorageService.kt
@@ -154,22 +154,13 @@ class FilesystemStorageService @Autowired constructor(properties: StoragePropert
     }
 
     override fun info(id: SimulationId): SimulationInfo {
-        return when (id) {
-            "demo" -> {
-                // for demo id, just make up some timestamps
-                createDemoSimulationInfo()
-            }
-
-            else -> {
-                val simulationDir = uploadsDir.resolve(Paths.get(id).normalize()).toAbsolutePath()
-                if (!simulationDir.exists()) {
-                    throw StorageSimulationNotFoundException("No such simulation with ID $id")
-                }
-                val infoFile = simulationDir.resolve("info.json").normalize().toAbsolutePath().toFile()
-                assert(infoFile.exists())
-                jsonMapper.readValue(infoFile)
-            }
+        val simulationDir = uploadsDir.resolve(Paths.get(id).normalize()).toAbsolutePath()
+        if (!simulationDir.exists()) {
+            throw StorageSimulationNotFoundException("No such simulation with ID $id")
         }
+        val infoFile = simulationDir.resolve("info.json").normalize().toAbsolutePath().toFile()
+        assert(infoFile.exists())
+        return jsonMapper.readValue(infoFile)
     }
 
     override fun export(simulationId: SimulationId): SumoNetwork {
@@ -195,20 +186,11 @@ class FilesystemStorageService @Autowired constructor(properties: StoragePropert
     }
 
     override fun listAll(): List<SimulationInfo> {
-        val simulationDirs = uploadsDir.listDirectoryEntries().filter { path -> path.fileName.toString() != "demo" }
-        val simulationInfos = mutableListOf(createDemoSimulationInfo())
-        simulationInfos.addAll(
-            simulationDirs.map<Path, SimulationInfo> { simulation ->
+        val simulationDirs = uploadsDir.listDirectoryEntries()
+            return simulationDirs.map<Path, SimulationInfo> { simulation ->
                 val infoFile = simulation.resolve("info.json").normalize().toAbsolutePath().toFile()
                 jsonMapper.readValue(infoFile)
             }.sortedByDescending { it.lastModifiedAt }
-        )
-        return simulationInfos
-    }
-
-    private fun createDemoSimulationInfo(): SimulationInfo {
-        val now = currentTime()
-        return SimulationInfo("demo", now, now)
     }
 
     private fun currentTime() = OffsetDateTime.now(ZoneOffset.UTC)


### PR DESCRIPTION
Since we can now generate simulations on our own, I don't think we really need the demo simulation anymore. So I no longer copy the `demo` folder to `uploads` and remove the code which prevents demo from being modified/deleted via the API.