### PR TITLE
Prevent shutdown hang because of unclosed simulations

### DIFF
--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
@@ -235,16 +235,10 @@ class SimulationController(
 
     @PreDestroy
     fun stopAllSimulations() {
-        logger.info { "Stopping all simulations" }
+        logger.info { "Server is shutting down. Stopping all simulations" }
         instances.values.forEach {instance ->
             instance.stopSimulation()
-            simpMessagingTemplate.convertAndSend(
-                "/topic/simulation/${instance.simulationId}/error",
-                mapOf("error" to "Server is shutting down")
-            )
-        }
-        disposables.values.forEach {disposable ->
-            disposable.dispose()
+            instance.next()
         }
     }
 }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
@@ -238,7 +238,7 @@ class SimulationController(
         logger.info { "Server is shutting down. Stopping all simulations" }
         instances.values.forEach {instance ->
             instance.stopSimulation()
-            instance.next()
+            instance.hasNext()
         }
     }
 }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
@@ -31,7 +31,11 @@ class SimulationInstance(
     private var frameTime = setSimulationSpeed(1)
     var flux = Flux.create<SimulationStep> { sink ->
         while (hasNext()) {
-            sink.next(next())
+            try {
+                sink.next(next())
+            } catch (_: UnknownError) {
+                logger.warn { "Simulation $simulationId with label $label forcibly closed. Ignore if server is shutting down" }
+            }
         }
         sink.complete()
     }


### PR DESCRIPTION
It seems that there's some race conditions which causes autowired beans like `simpMessagingTemplate` before `PreDestroy` hooks are run. So I made sure that all simulations are closed properly by forcibly calling `hasNext()` on `SimulationInstance` to induce the side effect.

Yes, this is a super ugly hack, but the alternative would be having malformed output xml every time the server shuts down.