### PR TITLE
Allow concurrent simulation (for real, hopefully)

### DIFF
--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
@@ -238,10 +238,6 @@ class SimulationController(
         logger.info { "Server is shutting down. Stopping all simulations" }
         instances.values.forEach { instance ->
             instance.forceCloseConnectionOnServerShutdown()
-//            instance.hasNext()
-        }
-        disposables.values.forEach { disposable ->
-            disposable.dispose()
         }
     }
 }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
@@ -236,9 +236,12 @@ class SimulationController(
     @PreDestroy
     fun stopAllSimulations() {
         logger.info { "Server is shutting down. Stopping all simulations" }
-        instances.values.forEach {instance ->
-            instance.stopSimulation()
-            instance.hasNext()
+        instances.values.forEach { instance ->
+            instance.forceCloseConnectionOnServerShutdown()
+//            instance.hasNext()
+        }
+        disposables.values.forEach { disposable ->
+            disposable.dispose()
         }
     }
 }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
@@ -31,18 +31,15 @@ class SimulationInstance(
     private val port: Int = getNextAvailablePort()
     private var frameTime = setSimulationSpeed(1)
     var flux = Flux.create<SimulationStep> { sink ->
-        try {
-            while (hasNext()) {
-                sink.next(next())
-            }
-        } catch (_: UnknownError) {
-            logger.warn { "Simulation $simulationId with label $label forcibly closed. Ignore if server is shutting down" }
+        while (hasNext()) {
+            sink.next(next())
         }
         sink.complete()
     }
 
     @Volatile
     private var shouldStop = false
+
     @Volatile
     private var connectionClosed = false
 

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
@@ -12,7 +12,6 @@ import java.nio.file.Path
 import java.time.Duration
 import java.time.Instant
 import java.util.concurrent.locks.ReentrantLock
-import kotlin.math.max
 
 
 typealias SimulationStep = Map<String, VehicleData>
@@ -127,9 +126,11 @@ class SimulationInstance(
         }
         // we've left the critical section here, so the sleep can be done asynchronously
         val end = Instant.now()
-        val delay = max(frameTime.toMillis() - Duration.between(start, end).toMillis(), 0)
-        logger.trace { "$label: sleeping for $delay ms" }
-        Thread.sleep(delay)
+        val delay = frameTime.toMillis() - Duration.between(start, end).toMillis()
+        if (delay > 0) {
+            logger.trace { "$label: sleeping for $delay ms" }
+            Thread.sleep(delay)
+        }
         return pairs
     }
 

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
@@ -52,7 +52,7 @@ class SimulationInstance(
         try {
             logger.info { "Connecting to SUMO with port $port and label $label" }
             lock.lock()
-            logger.info { "$label: lock acquired" }
+            logger.trace { "$label: lock acquired" }
             Simulation.start(
                 StringVector(arrayOf("sumo", "-c", cfgPath.toString())),
                 port,
@@ -61,7 +61,7 @@ class SimulationInstance(
             )
 
         } finally {
-            logger.info { "$label: releasing lock" }
+            logger.trace { "$label: releasing lock" }
             lock.unlock()
         }
     }
@@ -69,7 +69,7 @@ class SimulationInstance(
     override fun hasNext(): Boolean {
         try {
             lock.lock()
-            logger.info { "$label: lock acquired" }
+            logger.trace { "$label: lock acquired" }
             if (connectionClosed) {
                 return false
             }
@@ -89,7 +89,7 @@ class SimulationInstance(
             logger.error(e) { "Error in advancing simulation step" }
             throw SimulationException("Error in advancing simulation step: ${e.message}")
         } finally {
-            logger.info { "$label: releasing lock" }
+            logger.trace { "$label: releasing lock" }
             lock.unlock()
         }
     }
@@ -99,7 +99,7 @@ class SimulationInstance(
         val pairs: Map<String, VehicleData>
         try {
             lock.lock()
-            logger.info { "$label: lock acquired" }
+            logger.trace { "$label: lock acquired" }
 
             Simulation.switchConnection(label)
             Simulation.step()
@@ -125,7 +125,7 @@ class SimulationInstance(
             logger.error(e) { "Error in advancing simulation step" }
             throw SimulationException("Error in advancing simulation step: ${e.message}")
         } finally {
-            logger.info { "$label: releasing lock" }
+            logger.trace { "$label: releasing lock" }
             lock.unlock()
         }
         // we've left the critical section here, so the sleep can be done asynchronously
@@ -153,12 +153,12 @@ class SimulationInstance(
     fun forceCloseConnectionOnServerShutdown() {
         try {
             lock.lock()
-            logger.info { "$label: lock acquired" }
+            logger.trace { "$label: lock acquired" }
             Simulation.switchConnection(label)
             stopSimulation()
             closeSimulation()
         } finally {
-            logger.info { "$label: releasing lock" }
+            logger.trace { "$label: releasing lock" }
             lock.unlock()
         }
     }

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
@@ -68,11 +68,11 @@ class SimulationInstance(
         try {
             lock.lock()
             logger.info { "$label: lock acquired" }
+            Simulation.switchConnection(label)
             if (shouldStop) {
                 closeSimulation()
                 return false
             }
-            Simulation.switchConnection(label)
 
             val expected = Simulation.getMinExpectedNumber() > 0
             if (!expected) {

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/simulation/SimulationInstance.kt
@@ -131,7 +131,7 @@ class SimulationInstance(
         // we've left the critical section here, so the sleep can be done asynchronously
         val end = Instant.now()
         val delay = max(frameTime.toMillis() - Duration.between(start, end).toMillis(), 0)
-        logger.info { "$label: sleeping for $delay ms" }
+        logger.trace { "$label: sleeping for $delay ms" }
         Thread.sleep(delay)
         return pairs
     }


### PR DESCRIPTION
Start and stop multiple simulations at the same time without affecting others

From my observation, the main choke point for each simulation step is in the traci call itself, which takes more than 1 frame time. Because every single traci call is guarded by a lock, expect performance degradation when connecting multiple simulations.