### PR TITLE
Add (some) network validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.15.2")
+    implementation("org.springframework.boot:spring-boot-starter-validation:3.1.4")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
@@ -148,7 +148,7 @@ class SimulationController(
     )
     @PutMapping("/simulation/{id:.+}", consumes = ["application/json"], produces = ["application/json"])
     @ResponseBody
-    fun modifySimulation(@PathVariable id: SimulationId, @RequestBody network: SumoNetwork) = storageService.store(id, network)
+    fun modifySimulation(@PathVariable id: SimulationId, @Validated @RequestBody network: SumoNetwork) = storageService.store(id, network)
 
     @Operation(summary = "Get simulation information.")
     @ApiResponses(

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/model/ErrorResponse.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/model/ErrorResponse.kt
@@ -1,3 +1,3 @@
 package app.urbanflo.urbanflosumoserver.model
 
-data class ErrorResponse(val error: String)
+data class ErrorResponse(val error: String, val errorFields: Map<String, String?>? = null)

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/model/network/SumoNetwork.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/model/network/SumoNetwork.kt
@@ -2,11 +2,17 @@ package app.urbanflo.urbanflosumoserver.model.network
 
 import app.urbanflo.urbanflosumoserver.model.SimulationInfo
 import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotEmpty
 
 data class SumoNetwork(
+    @field:NotBlank(message = "Document name cannot be blank")
     val documentName: String,
+    @field:NotEmpty(message = "Nodes must not be empty")
     val nodes: List<SumoNode>,
+    @field:NotEmpty(message = "Edges must not be empty")
     val edges: List<SumoEdge>,
+    @field:NotEmpty(message = "Connections must not be empty")
     val connections: List<SumoConnection>,
     @JsonProperty("vType")
     val vehicleType: List<SumoVehicleType>,

--- a/src/test/kotlin/app/urbanflo/urbanflosumoserver/ApiTests.kt
+++ b/src/test/kotlin/app/urbanflo/urbanflosumoserver/ApiTests.kt
@@ -89,7 +89,7 @@ class ApiTests(@Autowired private val restTemplate: TestRestTemplate) {
     @Test
     fun testInvalidDocumentName() {
         val baseNetworkObject = jsonMapper.readValue<SumoNetwork>(simpleNetwork)
-        val documentNames = arrayOf("", " ", "\n", "\r\n", "\u0000")
+        val documentNames = arrayOf("", " ", "\n", "\r\n", "\u0000", "\t")
         documentNames.forEach { name ->
             val networkObject = SumoNetwork(
                 name,
@@ -106,6 +106,62 @@ class ApiTests(@Autowired private val restTemplate: TestRestTemplate) {
                 restTemplate.postForEntity("http://localhost:${port}/simulation", request)
             assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
             assertTrue("documentName" in response.body!!.errorFields!!.keys)
+        }
+    }
+
+    /**
+     * Test document names that are technically valid (i.e. not blank and is valid JSON string) but may pose problems
+     * in the frontend depending on the platform
+     */
+    @Test
+    fun testProblematicDocumentNames() {
+        val baseNetworkObject = jsonMapper.readValue<SumoNetwork>(simpleNetwork)
+        val documentNames = arrayOf(
+            // non-ascii characters
+            "Безымянный документ",
+            "وثيقة بدون عنوان",
+            "Untitled Document وثيقة بدون عنوان Безымянный докумен",
+            // emojis
+            "\uD83D\uDE02", // 😂
+            "\uD83C\uDDE6\uD83C\uDDFA", // 🇦🇺 -- flag of Australia
+            // names containing forbidden windows filenames
+            // https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
+            "Untitled Document 1\\10",
+            "Untitled Document.",
+            "Untitled Document?",
+            "Untitled Document ",
+            "Untitled Document 2: Electric Boogaloo",
+            "con",
+            "Con",
+            "CON",
+            "A".repeat(1000),
+            // other problematic filesystem document names
+            "Untitled Document 1/10",
+            "Untitled Document\u0000",
+            ".",
+            "..",
+            ".Untitled",
+            // other
+            "\"Untitled Document\"",
+            "\\n",
+            "\\0"
+        )
+        documentNames.forEach { name ->
+            val networkObject = SumoNetwork(
+                name,
+                baseNetworkObject.nodes,
+                baseNetworkObject.edges,
+                baseNetworkObject.connections,
+                baseNetworkObject.vehicleType,
+                baseNetworkObject.route,
+                baseNetworkObject.flow
+            )
+            val network = jsonMapper.writeValueAsString(networkObject)
+            val request = HttpEntity(network, httpHeaders)
+            val response: ResponseEntity<SimulationInfo> =
+                restTemplate.postForEntity("http://localhost:${port}/simulation", request)
+            assertEquals(HttpStatus.CREATED, response.statusCode)
+            assertEquals(name, response.body!!.documentName) // test response decoding
         }
     }
 


### PR DESCRIPTION
Currently implemented validations:

- `documentName` cannot be empty (i.e. can't be empty or consists only of spaces and/or newlines)
- `nodes`, `edges` and `connections` cannot be empty

400 error will be returned on validation error.

Also added tests for potentially problematic document names (e.g. those not allowed by filesystems)