### PR TITLE
Validate edge properties

### DIFF
--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/controller/SimulationController.kt
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.annotation.PreDestroy
+import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.messaging.handler.annotation.DestinationVariable
@@ -26,7 +27,6 @@ import org.springframework.messaging.handler.annotation.MessageMapping
 import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
 import org.springframework.validation.FieldError
-import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.*
 import reactor.core.Disposable
@@ -108,7 +108,7 @@ class SimulationController(
     @PostMapping("/simulation", consumes = ["application/json"], produces = ["application/json"])
     @ResponseStatus(HttpStatus.CREATED)
     @ResponseBody
-    fun newSimulation(@Validated @RequestBody network: SumoNetwork) = storageService.store(network)
+    fun newSimulation(@Valid @RequestBody network: SumoNetwork) = storageService.store(network)
 
     @Operation(summary = "Delete a simulation.")
     @ApiResponses(
@@ -148,7 +148,8 @@ class SimulationController(
     )
     @PutMapping("/simulation/{id:.+}", consumes = ["application/json"], produces = ["application/json"])
     @ResponseBody
-    fun modifySimulation(@PathVariable id: SimulationId, @Validated @RequestBody network: SumoNetwork) = storageService.store(id, network)
+    fun modifySimulation(@PathVariable id: SimulationId, @Valid @RequestBody network: SumoNetwork) =
+        storageService.store(id, network)
 
     @Operation(summary = "Get simulation information.")
     @ApiResponses(
@@ -299,7 +300,7 @@ class SimulationController(
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidationErrors(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> {
-        val fields = e.allErrors.associate{ err -> (err as FieldError).field to err.defaultMessage}.toMap()
+        val fields = e.allErrors.associate { err -> (err as FieldError).field to err.defaultMessage }.toMap()
         return ResponseEntity(ErrorResponse("Invalid JSON body", fields), HttpStatus.BAD_REQUEST)
     }
 

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/model/network/SumoEdge.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/model/network/SumoEdge.kt
@@ -1,6 +1,8 @@
 package app.urbanflo.urbanflosumoserver.model.network
 
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty
+import jakarta.validation.constraints.Positive
+import jakarta.validation.constraints.PositiveOrZero
 
 data class SumoEdge(
     @field:JacksonXmlProperty(isAttribute = true)
@@ -12,21 +14,15 @@ data class SumoEdge(
     @field:JacksonXmlProperty(isAttribute = true)
     val priority: Int,
     @field:JacksonXmlProperty(isAttribute = true)
+    @field:Positive(message = "numLanes must be a positive value")
     val numLanes: Int,
     @field:JacksonXmlProperty(isAttribute = true)
+    @field:PositiveOrZero(message = "speed cannot be negative")
     val speed: Double,
     @field:JacksonXmlProperty(isAttribute = true)
     val width: Double,
     @field:JacksonXmlProperty(isAttribute = true)
     val name: String?,
     @field:JacksonXmlProperty(isAttribute = true)
-    val spreadType: String?,
-) {
-    init {
-        spreadType?.let {
-            require(it in listOf("right", "center", "roadCenter")) {
-                "Invalid value for spreadType: $it. Allowed values are 'right', 'center' and 'roadCenter'"
-            }
-        }
-    }
-}
+    val spreadType: SumoSpreadType?,
+)

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/model/network/SumoNetwork.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/model/network/SumoNetwork.kt
@@ -2,6 +2,7 @@ package app.urbanflo.urbanflosumoserver.model.network
 
 import app.urbanflo.urbanflosumoserver.model.SimulationInfo
 import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotEmpty
 
@@ -11,10 +12,11 @@ data class SumoNetwork(
     @field:NotEmpty(message = "Nodes must not be empty")
     val nodes: List<SumoNode>,
     @field:NotEmpty(message = "Edges must not be empty")
+    @field:Valid
     val edges: List<SumoEdge>,
     @field:NotEmpty(message = "Connections must not be empty")
     val connections: List<SumoConnection>,
-    @JsonProperty("vType")
+    @field:JsonProperty("vType")
     val vehicleType: List<SumoVehicleType>,
     val route: List<SumoRoute>,
     val flow: List<SumoFlow>

--- a/src/main/kotlin/app/urbanflo/urbanflosumoserver/model/network/SumoSpreadType.kt
+++ b/src/main/kotlin/app/urbanflo/urbanflosumoserver/model/network/SumoSpreadType.kt
@@ -1,0 +1,9 @@
+package app.urbanflo.urbanflosumoserver.model.network
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+enum class SumoSpreadType(@JsonValue val spreadType: String) {
+    RIGHT("right"),
+    CENTER("center"),
+    ROAD_CENTER("roadCenter")
+}

--- a/src/test/kotlin/app/urbanflo/urbanflosumoserver/ApiTests.kt
+++ b/src/test/kotlin/app/urbanflo/urbanflosumoserver/ApiTests.kt
@@ -41,6 +41,7 @@ class ApiTests(@Autowired private val restTemplate: TestRestTemplate) {
     val fourWayIntersection = ClassPathResource("4-way-intersection.json").file.readText()
     val noEdgeNetwork = ClassPathResource("no-edges.json").file.readText()
     val missingFields = ClassPathResource("missing-fields.json").file.readText()
+    val invalidEdges = ClassPathResource("invalid-edges.json").file.readText()
 
     init {
         xmlMapper.configure(ToXmlGenerator.Feature.WRITE_XML_DECLARATION, true)
@@ -181,6 +182,17 @@ class ApiTests(@Autowired private val restTemplate: TestRestTemplate) {
         // at the moment, we can't distinguish between bad networks and other netconvert errors
         assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
         assertTrue("edges" in response.body!!.errorFields!!.keys)
+    }
+
+    @Test
+    fun testInvalidEdges() {
+        val request = HttpEntity(invalidEdges, httpHeaders)
+        val response: ResponseEntity<ErrorResponse> =
+            restTemplate.postForEntity("http://localhost:${port}/simulation", request)
+        // at the moment, we can't distinguish between bad networks and other netconvert errors
+        assertEquals(HttpStatus.BAD_REQUEST, response.statusCode)
+        assertTrue("edges[0].numLanes" in response.body!!.errorFields!!.keys)
+        assertTrue("edges[0].speed" in response.body!!.errorFields!!.keys)
     }
 
 

--- a/src/test/resources/invalid-edges.json
+++ b/src/test/resources/invalid-edges.json
@@ -1,0 +1,276 @@
+{
+  "documentName": "invalid-edges",
+  "nodes": [
+    {
+      "id": "h3to4dntqx",
+      "x": 942,
+      "y": 363,
+      "type": "priority"
+    },
+    {
+      "id": "g1j2yhk96k",
+      "x": 570,
+      "y": 360,
+      "type": "priority"
+    },
+    {
+      "id": "j8y6e8wxhr",
+      "x": 1221,
+      "y": 371,
+      "type": "priority"
+    },
+    {
+      "id": "uaek4h9egd",
+      "x": 943,
+      "y": 564,
+      "type": "priority"
+    }
+  ],
+  "edges": [
+    {
+      "id": "g1j2yhk96k_h3to4dntqx",
+      "from": "g1j2yhk96k",
+      "to": "h3to4dntqx",
+      "priority": -1,
+      "numLanes": -1,
+      "spreadType": "center",
+      "width": 25,
+      "speed": -1,
+      "name": "New Road"
+    },
+    {
+      "id": "h3to4dntqx_g1j2yhk96k",
+      "from": "h3to4dntqx",
+      "to": "g1j2yhk96k",
+      "priority": -1,
+      "numLanes": 1,
+      "spreadType": "center",
+      "width": 25,
+      "speed": 13.89,
+      "name": "New Road"
+    },
+    {
+      "id": "uaek4h9egd_h3to4dntqx",
+      "from": "uaek4h9egd",
+      "to": "h3to4dntqx",
+      "priority": -1,
+      "numLanes": 1,
+      "spreadType": "center",
+      "width": 25,
+      "speed": 13.89,
+      "name": "New Road"
+    },
+    {
+      "id": "h3to4dntqx_uaek4h9egd",
+      "from": "h3to4dntqx",
+      "to": "uaek4h9egd",
+      "priority": -1,
+      "numLanes": 1,
+      "spreadType": "center",
+      "width": 25,
+      "speed": 13.89,
+      "name": "New Road"
+    },
+    {
+      "id": "j8y6e8wxhr_h3to4dntqx",
+      "from": "j8y6e8wxhr",
+      "to": "h3to4dntqx",
+      "priority": -1,
+      "numLanes": 1,
+      "spreadType": "center",
+      "width": 25,
+      "speed": 13.89,
+      "name": "New Road"
+    },
+    {
+      "id": "h3to4dntqx_j8y6e8wxhr",
+      "from": "h3to4dntqx",
+      "to": "j8y6e8wxhr",
+      "priority": -1,
+      "numLanes": 1,
+      "spreadType": "center",
+      "width": 25,
+      "speed": 13.89,
+      "name": "New Road"
+    }
+  ],
+  "connections": [
+    {
+      "from": "g1j2yhk96k_h3to4dntqx",
+      "to": "h3to4dntqx_g1j2yhk96k",
+      "fromLane": 0,
+      "toLane": 0
+    },
+    {
+      "from": "uaek4h9egd_h3to4dntqx",
+      "to": "h3to4dntqx_g1j2yhk96k",
+      "fromLane": 0,
+      "toLane": 0
+    },
+    {
+      "from": "g1j2yhk96k_h3to4dntqx",
+      "to": "h3to4dntqx_uaek4h9egd",
+      "fromLane": 0,
+      "toLane": 0
+    },
+    {
+      "from": "uaek4h9egd_h3to4dntqx",
+      "to": "h3to4dntqx_uaek4h9egd",
+      "fromLane": 0,
+      "toLane": 0
+    },
+    {
+      "from": "j8y6e8wxhr_h3to4dntqx",
+      "to": "h3to4dntqx_g1j2yhk96k",
+      "fromLane": 0,
+      "toLane": 0
+    },
+    {
+      "from": "j8y6e8wxhr_h3to4dntqx",
+      "to": "h3to4dntqx_uaek4h9egd",
+      "fromLane": 0,
+      "toLane": 0
+    },
+    {
+      "from": "g1j2yhk96k_h3to4dntqx",
+      "to": "h3to4dntqx_j8y6e8wxhr",
+      "fromLane": 0,
+      "toLane": 0
+    },
+    {
+      "from": "uaek4h9egd_h3to4dntqx",
+      "to": "h3to4dntqx_j8y6e8wxhr",
+      "fromLane": 0,
+      "toLane": 0
+    },
+    {
+      "from": "j8y6e8wxhr_h3to4dntqx",
+      "to": "h3to4dntqx_j8y6e8wxhr",
+      "fromLane": 0,
+      "toLane": 0
+    }
+  ],
+  "vType": [
+    {
+      "id": "car",
+      "accel": 2.6,
+      "decel": 4.5,
+      "sigma": 1,
+      "length": 5,
+      "minGap": 2.5,
+      "maxSpeed": 30
+    }
+  ],
+  "route": [
+    {
+      "id": "g1j2yhk96k_to_g1j2yhk96k",
+      "edges": "g1j2yhk96k_h3to4dntqx h3to4dntqx_g1j2yhk96k"
+    },
+    {
+      "id": "uaek4h9egd_to_g1j2yhk96k",
+      "edges": "uaek4h9egd_h3to4dntqx h3to4dntqx_g1j2yhk96k"
+    },
+    {
+      "id": "g1j2yhk96k_to_uaek4h9egd",
+      "edges": "g1j2yhk96k_h3to4dntqx h3to4dntqx_uaek4h9egd"
+    },
+    {
+      "id": "uaek4h9egd_to_uaek4h9egd",
+      "edges": "uaek4h9egd_h3to4dntqx h3to4dntqx_uaek4h9egd"
+    },
+    {
+      "id": "j8y6e8wxhr_to_g1j2yhk96k",
+      "edges": "j8y6e8wxhr_h3to4dntqx h3to4dntqx_g1j2yhk96k"
+    },
+    {
+      "id": "j8y6e8wxhr_to_uaek4h9egd",
+      "edges": "j8y6e8wxhr_h3to4dntqx h3to4dntqx_uaek4h9egd"
+    },
+    {
+      "id": "g1j2yhk96k_to_j8y6e8wxhr",
+      "edges": "g1j2yhk96k_h3to4dntqx h3to4dntqx_j8y6e8wxhr"
+    },
+    {
+      "id": "uaek4h9egd_to_j8y6e8wxhr",
+      "edges": "uaek4h9egd_h3to4dntqx h3to4dntqx_j8y6e8wxhr"
+    },
+    {
+      "id": "j8y6e8wxhr_to_j8y6e8wxhr",
+      "edges": "j8y6e8wxhr_h3to4dntqx h3to4dntqx_j8y6e8wxhr"
+    }
+  ],
+  "flow": [
+    {
+      "id": "flow_g1j2yhk96k_h3to4dntqxh3to4dntqx_g1j2yhk96k",
+      "type": "car",
+      "route": "g1j2yhk96k_to_g1j2yhk96k",
+      "begin": 0,
+      "end": 86400,
+      "vehsPerHour": 1000
+    },
+    {
+      "id": "flow_uaek4h9egd_h3to4dntqxh3to4dntqx_g1j2yhk96k",
+      "type": "car",
+      "route": "uaek4h9egd_to_g1j2yhk96k",
+      "begin": 0,
+      "end": 86400,
+      "vehsPerHour": 1000
+    },
+    {
+      "id": "flow_g1j2yhk96k_h3to4dntqxh3to4dntqx_uaek4h9egd",
+      "type": "car",
+      "route": "g1j2yhk96k_to_uaek4h9egd",
+      "begin": 0,
+      "end": 86400,
+      "vehsPerHour": 1000
+    },
+    {
+      "id": "flow_uaek4h9egd_h3to4dntqxh3to4dntqx_uaek4h9egd",
+      "type": "car",
+      "route": "uaek4h9egd_to_uaek4h9egd",
+      "begin": 0,
+      "end": 86400,
+      "vehsPerHour": 1000
+    },
+    {
+      "id": "flow_j8y6e8wxhr_h3to4dntqxh3to4dntqx_g1j2yhk96k",
+      "type": "car",
+      "route": "j8y6e8wxhr_to_g1j2yhk96k",
+      "begin": 0,
+      "end": 86400,
+      "vehsPerHour": 1000
+    },
+    {
+      "id": "flow_j8y6e8wxhr_h3to4dntqxh3to4dntqx_uaek4h9egd",
+      "type": "car",
+      "route": "j8y6e8wxhr_to_uaek4h9egd",
+      "begin": 0,
+      "end": 86400,
+      "vehsPerHour": 1000
+    },
+    {
+      "id": "flow_g1j2yhk96k_h3to4dntqxh3to4dntqx_j8y6e8wxhr",
+      "type": "car",
+      "route": "g1j2yhk96k_to_j8y6e8wxhr",
+      "begin": 0,
+      "end": 86400,
+      "vehsPerHour": 1000
+    },
+    {
+      "id": "flow_uaek4h9egd_h3to4dntqxh3to4dntqx_j8y6e8wxhr",
+      "type": "car",
+      "route": "uaek4h9egd_to_j8y6e8wxhr",
+      "begin": 0,
+      "end": 86400,
+      "vehsPerHour": 1000
+    },
+    {
+      "id": "flow_j8y6e8wxhr_h3to4dntqxh3to4dntqx_j8y6e8wxhr",
+      "type": "car",
+      "route": "j8y6e8wxhr_to_j8y6e8wxhr",
+      "begin": 0,
+      "end": 86400,
+      "vehsPerHour": 1000
+    }
+  ]
+}


### PR DESCRIPTION
When `numLanes` is negative, `netconvert` would segfault (!!!), and besides, I want to reduce the amount of 500 errors being thrown and replace it with more descriptive errors.